### PR TITLE
Soil scoring

### DIFF
--- a/gaia/scoring/scoring.py
+++ b/gaia/scoring/scoring.py
@@ -24,3 +24,23 @@ class Scoring:
 
     def _calculate_final_weights(self):
         pass
+
+    def aggregate_task_scores(self, geomagnetic_scores: dict, soil_scores: dict) -> List[float]:
+        """Combines scores from multiple tasks into final weights"""
+        weights = [0.0] * 256
+        
+        for idx in range(256):
+            geo_score = geomagnetic_scores.get(idx, float('nan'))
+            soil_score = soil_scores.get(idx, float('nan'))
+            
+            if math.isnan(geo_score) and math.isnan(soil_score):
+                weights[idx] = 0.0
+            elif math.isnan(geo_score):
+                weights[idx] = 0.5 * soil_score
+            elif math.isnan(soil_score):
+                weights[idx] = 0.5 * math.exp(-abs(geo_score) / 10)
+            else:
+                geo_normalized = math.exp(-abs(geo_score) / 10)
+                weights[idx] = 0.5 * geo_normalized + 0.5 * soil_score
+                
+        return weights

--- a/gaia/tasks/defined_tasks/soilmoisture/soil_scoring_mechanism.py
+++ b/gaia/tasks/defined_tasks/soilmoisture/soil_scoring_mechanism.py
@@ -4,7 +4,7 @@ import tempfile
 from gaia.tasks.base.components.scoring_mechanism import ScoringMechanism
 from gaia.tasks.base.decorators import task_timer
 import numpy as np
-from typing import Dict, Optional
+from typing import Dict, Optional, Any
 from rasterio.coords import BoundingBox
 from rasterio.crs import CRS
 import torch
@@ -19,6 +19,9 @@ from pydantic import Field
 from fiber.logging_utils import get_logger
 import os
 import traceback
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine, async_sessionmaker
+from sqlalchemy.sql import text
+from datetime import timezone
 
 logger = get_logger(__name__)
 
@@ -29,14 +32,19 @@ class SoilScoringMechanism(ScoringMechanism):
     alpha: float = Field(default=10, description="Sigmoid steepness parameter")
     beta: float = Field(default=0.1, description="Sigmoid midpoint parameter")
     baseline_rmse: float = Field(default=50, description="Baseline RMSE value")
+    db_manager: Any = Field(default=None)
 
-    def __init__(self, baseline_rmse: float = 50, alpha: float = 10, beta: float = 0.1):
+    def __init__(self, baseline_rmse: float = 50, alpha: float = 10, beta: float = 0.1, db_manager=None):
         super().__init__(
             name="SoilMoistureScoringMechanism",
             description="Evaluates soil moisture predictions using RMSE and SSIM",
             normalize_score=True,
             max_score=1.0,
         )
+        self.alpha = alpha
+        self.beta = beta
+        self.baseline_rmse = baseline_rmse
+        self.db_manager = db_manager
 
     def sigmoid_rmse(self, rmse: float) -> float:
         """Convert RMSE to score using sigmoid function. (higher is better)"""
@@ -134,6 +142,7 @@ class SoilScoringMechanism(ScoringMechanism):
                 crs=predictions["crs"],
                 model_predictions=predictions["predictions"],
                 target_date=predictions["target_time"],
+                miner_id=predictions["miner_id"]
             )
 
             if not metrics:
@@ -170,6 +179,7 @@ class SoilScoringMechanism(ScoringMechanism):
         crs: float,
         model_predictions: torch.Tensor,
         target_date: datetime,
+        miner_id: str,
     ) -> dict:
         """
         Compute RMSE and SSIM between model predictions and SMAP data for valid pixels only.
@@ -179,6 +189,7 @@ class SoilScoringMechanism(ScoringMechanism):
             crs: EPSG code as float
             model_predictions: tensor of shape [1, 2, 11, 11] for surface and rootzone
             target_date: datetime for SMAP data
+            miner_id: miner's unique identifier
         """
         device = model_predictions.device
 
@@ -244,6 +255,9 @@ class SoilScoringMechanism(ScoringMechanism):
             # early return if no valid pixels (.i.e no valid smap data)
             if not (surface_mask_11x11.any() or rootzone_mask_11x11.any()):
                 logger.warning(f"No valid SMAP data found for bounds {bounds}")
+                cleanup_success = await self.cleanup_invalid_prediction(bounds, target_date, miner_id)
+                if not cleanup_success:
+                    logger.error(f"Failed to cleanup invalid prediction for bounds {bounds}")
                 return None
 
             results = {"validation_metrics": {}}
@@ -330,3 +344,62 @@ class SoilScoringMechanism(ScoringMechanism):
 
                 except:
                     pass
+
+    async def cleanup_invalid_prediction(self, bounds, target_time: datetime, miner_id: str, conn=None):
+        """Clean up predictions for a specific miner and timestamp."""
+        try:
+            if not conn:
+                conn = await self.db_manager.get_connection()
+            
+            async with conn.begin():
+                debug_result = await conn.execute(
+                    text("""
+                    SELECT 
+                        p.id as pred_id,
+                        p.miner_uid,
+                        r.target_time,
+                        r.region_date,
+                        r.sentinel_bounds
+                    FROM soil_moisture_predictions p
+                    JOIN soil_moisture_regions r ON p.region_id = r.id
+                    WHERE p.miner_uid = :miner_id 
+                    AND p.status = 'sent_to_miner'
+                    AND r.sentinel_bounds = ARRAY[:b1, :b2, :b3, :b4]::float[]
+                    """),
+                    {
+                        "miner_id": miner_id,
+                        "b1": bounds[0],
+                        "b2": bounds[1],
+                        "b3": bounds[2],
+                        "b4": bounds[3]
+                    }
+                )
+                
+                row = debug_result.first()
+                if row:
+                    logger.info(f"Found prediction - ID: {row.pred_id}, Time: {row.target_time}, Date: {row.region_date}")
+                    result = await conn.execute(
+                        text("""
+                        DELETE FROM soil_moisture_predictions p
+                        WHERE p.id = :pred_id
+                        RETURNING p.id
+                        """),
+                        {"pred_id": row.pred_id}
+                    )
+                    
+                    deleted = result.first()
+                    if deleted:
+                        logger.info(f"Removed prediction {deleted.id}")
+                        return True
+                else:
+                    logger.warning(f"No predictions found for miner {miner_id} with bounds {bounds}")
+                
+                return False
+
+        except Exception as e:
+            logger.error(f"Failed to cleanup invalid prediction: {e}")
+            logger.error(traceback.format_exc())
+            return False
+        finally:
+            if conn and not isinstance(conn, AsyncSession):
+                await conn.close()

--- a/gaia/tasks/defined_tasks/soilmoisture/soil_validator_preprocessing.py
+++ b/gaia/tasks/defined_tasks/soilmoisture/soil_validator_preprocessing.py
@@ -5,10 +5,11 @@ from gaia.validator.database.validator_database_manager import ValidatorDatabase
 from gaia.tasks.defined_tasks.soilmoisture.utils.region_selection import (
     select_random_region,
 )
-from gaia.tasks.defined_tasks.soilmoisture.utils.soil_apis import get_soil_data
+from gaia.tasks.defined_tasks.soilmoisture.utils.soil_apis import get_soil_data, get_data_dir
 import json
 from typing import Dict, Optional, List
 import os
+import shutil
 from sqlalchemy import text
 from fiber.logging_utils import get_logger
 
@@ -206,6 +207,22 @@ class SoilValidatorPreprocessing(Preprocessing):
                         region_data["id"] = region_id
                         regions.append(region_data)
                         self._update_daily_count(target_time)
+
+                        data_dir = get_data_dir()
+                        for filename in os.listdir(data_dir):
+                            filepath = os.path.join(data_dir, filename)
+                            if os.path.isdir(filepath) and filename.startswith('tmp'):
+                                try:
+                                    shutil.rmtree(filepath)
+                                    logger.info(f"Removed temp directory: {filepath}")
+                                except Exception as e:
+                                    logger.error(f"Failed to remove temp directory {filepath}: {e}")
+                            elif filename.endswith('.tif'):
+                                try:
+                                    os.remove(filepath)
+                                    logger.info(f"Removed tif file: {filepath}")
+                                except Exception as e:
+                                    logger.error(f"Failed to remove tif file {filepath}: {e}")
 
                 except Exception as e:
                     logger.error(f"Error processing region: {str(e)}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ asyncpg==0.30.0
 attrs==24.2.0
 base58==2.1.1
 black==24.10.0
+boto3==1.35.75
 certifi==2024.8.30
 cffi==1.17.1
 cfgrib==0.9.14.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = gaia
-version = 1.0.0
+version = 1.0.1
 database_version = 1.0.0
 author = geardici, oneandahalfcats, qucat, gabby
 organization = Nickel5


### PR DESCRIPTION
# Gaia 1.0.1 Hotfix

## Soil Task
- Fixed timestep windows not correctly querying miners
- Fixed storage of miner predictions with proper task_id and miner mapping
- Fixed scoring system to properly evaluate predictions against ground truth
- Implemented proper cleanup of temporary files
- Aligned scoring delay with 3-day validation window
-  Added S3 Copernicus DEM elevation data backup 

## Weight Setting
- Added logic to skip weight setting when no valid scores are available
- Implemented 0.5 total weight distribution when only one task has scores
- Fixed weight setting frequency to wait 300 blocks
- Fixed normalization of geomagnetic scores
- Added validation checks before setting weights on chain
- Fixed score table querying to use most recent valid scores

## General Improvements
- Improved error handling and logging across tasks
- Aligned timestamp handling between tasks for consistent scoring windows
- Added proper validation of score data before weight calculations