### PR TITLE
Fiber upgrade + CR3

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Gaia is a platform for research and development of geospatial machine learning m
 Read more about the long-term vision in our [whitepaper](https://www.gaiaresearch.ai/whitepaper).
 
 >[!NOTE]
-> BETA VERSION = 1.0.0
+> BETA VERSION = 1.0.2
 >
 > The beta version of Gaia launches with limited functionality. Many of the planned features are not yet available, however we are still accepting miners and validators for the initial tasks. 
 
@@ -54,7 +54,7 @@ source ../.gaia/bin/activate
 
 ----
 ```bash
-pip install "git+https://github.com/rayonlabs/fiber.git@1.0.0#egg=fiber[full]"
+pip install "git+https://github.com/rayonlabs/fiber.git@production#egg=fiber[full]"
 ```
 
 

--- a/gaia/models/geomag_basemodel.py
+++ b/gaia/models/geomag_basemodel.py
@@ -1,5 +1,7 @@
 import traceback
 import pandas as pd
+import logging
+logging.getLogger("prophet.plot").disabled = True
 from prophet import Prophet
 from datetime import datetime, timedelta
 import pytz

--- a/gaia/tasks/base/components/scoring_mechanism.py
+++ b/gaia/tasks/base/components/scoring_mechanism.py
@@ -1,39 +1,148 @@
 from pydantic import BaseModel, Field
 from abc import ABC, abstractmethod
-from typing import Dict, Any, Optional
-from ..decorators import task_timer
-from .inputs import Inputs
-from .outputs import Outputs
+from typing import List, Dict, Any, Optional
+import math
+import asyncio
+from datetime import datetime, timezone
+from fiber.logging_utils import get_logger
 
+logger = get_logger(__name__)
 
 class ScoringMechanism(BaseModel, ABC):
-    """Base class for all scoring mechanisms.
+    """
+    Base class for all scoring mechanisms.
 
-    The ScoringMechanism base class represents the scoring mechanism of a subtask.
-    Should be extended to define specific scoring mechanisms for different subtasks, to be run by the validator.
+    Provides a modular interface for scoring tasks with shared methods for:
+    - Score calculation
+    - Normalization
+    - Prediction and score saving
 
-    - Inputs here are NOT the same as the inputs of the subtask. Rather, they are the inputs of the scoring mechanism (Ground Truth, API data, etc)
-
-    - Outputs ARE the the result of the subtask completed by the miner.
-
-    inputs: Dict[str, Any]
-    outputs: Dict[str, Any]
+    Should be extended to define specific scoring mechanisms for different tasks.
     """
 
     name: str = Field(..., description="Name of the scoring mechanism")
     description: str = Field(..., description="Description of how scoring works")
-    normalize_score: bool = Field(
-        default=True, description="Whether to normalize the score"
-    )
+    normalize_score: bool = Field(default=True, description="Whether to normalize the score")
     max_score: float = Field(default=100.0, description="Maximum possible score")
-
-    model_config = {"arbitrary_types_allowed": True}
+    db_manager: Any = Field(default=None, description="Database manager for saving predictions and scores")
 
     @abstractmethod
-    @task_timer
-    def score(self, predictions: Any, ground_truth: Any) -> Dict[str, float]:
+    def calculate_score(self, predicted_value: float, actual_value: float) -> float:
         """
-        Score the outputs of a subtask against ground truth.
-        Returns a dictionary of score metrics.
+        Calculate the score for a single prediction.
+
+        Args:
+            predicted_value (float): The predicted value.
+            actual_value (float): The ground truth value.
+
+        Returns:
+            float: The calculated score.
         """
         pass
+
+    def normalize_scores(self, scores: List[float]) -> List[float]:
+        """
+        Normalize scores to the range [0, 1].
+
+        Args:
+            scores (List[float]): List of raw scores.
+
+        Returns:
+            List[float]: Normalized scores.
+        """
+        valid_scores = [score for score in scores if not math.isnan(score)]
+
+        if not valid_scores:
+            logger.warning("All scores are NaN. Returning default normalized scores.")
+            return [0.0 for _ in scores]
+
+        min_score = min(valid_scores)
+        max_score = max(valid_scores)
+
+        if max_score == min_score:
+            return [1.0 for _ in scores]  # All valid scores are the same
+
+        return [(score - min_score) / (max_score - min_score) if not math.isnan(score) else 0.0 for score in scores]
+
+    async def save_predictions(self, predictions: List[Dict[str, Any]], table_name: str):
+        """
+        Save predictions to the specified database table.
+
+        Args:
+            predictions (List[Dict[str, Any]]): List of prediction dictionaries.
+            table_name (str): Name of the table to save predictions.
+        """
+        try:
+            query = f"""
+            INSERT INTO {table_name} (id, miner_uid, miner_hotkey, predicted_value, query_time, status)
+            VALUES (:id, :miner_uid, :miner_hotkey, :predicted_value, CURRENT_TIMESTAMP, 'pending')
+            ON CONFLICT (id) DO NOTHING
+            """
+            for prediction in predictions:
+                await self.db_manager.execute(query, prediction)
+            logger.info(f"Successfully saved {len(predictions)} predictions to {table_name}.")
+        except Exception as e:
+            logger.error(f"Error saving predictions to {table_name}: {e}")
+
+    async def save_scores(self, scores: List[Dict[str, Any]], table_name: str):
+        """
+        Save scores to the specified database table.
+
+        Args:
+            scores (List[Dict[str, Any]]): List of score dictionaries.
+            table_name (str): Name of the table to save scores.
+        """
+        try:
+            query = f"""
+            INSERT INTO {table_name} (miner_uid, miner_hotkey, query_time, predicted_value, ground_truth_value, score, scored_at)
+            VALUES (:miner_uid, :miner_hotkey, :query_time, :predicted_value, :ground_truth_value, :score, CURRENT_TIMESTAMP)
+            """
+            for score in scores:
+                await self.db_manager.execute(query, score)
+            logger.info(f"Successfully saved {len(scores)} scores to {table_name}.")
+        except Exception as e:
+            logger.error(f"Error saving scores to {table_name}: {e}")
+
+    async def score(self, predictions: List[Dict[str, Any]], ground_truth: float, prediction_table: str, score_table: str):
+        """
+        Score multiple predictions, normalize scores, and save them.
+
+        Args:
+            predictions (List[Dict[str, Any]]): List of prediction dictionaries containing:
+                - id
+                - miner_uid
+                - miner_hotkey
+                - predicted_value
+            ground_truth (float): The ground truth value.
+            prediction_table (str): Table name for saving predictions.
+            score_table (str): Table name for saving scores.
+
+        Returns:
+            List[Dict[str, Any]]: List of score dictionaries with scores and metadata.
+        """
+        try:
+            if not isinstance(predictions, list) or not isinstance(ground_truth, (int, float)):
+                raise ValueError("Invalid predictions or ground truth format.")
+
+            miner_scores = []
+            for prediction in predictions:
+                score_value = self.calculate_score(prediction["predicted_value"], ground_truth)
+                miner_scores.append({
+                    "miner_uid": prediction["miner_uid"],
+                    "miner_hotkey": prediction["miner_hotkey"],
+                    "query_time": prediction.get("query_time", datetime.now(timezone.utc)),
+                    "predicted_value": prediction["predicted_value"],
+                    "ground_truth_value": ground_truth,
+                    "score": score_value
+                })
+
+            # Save predictions
+            await self.save_predictions(predictions, prediction_table)
+
+            # Save scores
+            await self.save_scores(miner_scores, score_table)
+
+            return miner_scores
+        except Exception as e:
+            logger.error(f"Error in scoring process: {e}")
+            return []

--- a/gaia/tasks/base/components/scoring_mechanism.py
+++ b/gaia/tasks/base/components/scoring_mechanism.py
@@ -1,148 +1,39 @@
 from pydantic import BaseModel, Field
 from abc import ABC, abstractmethod
-from typing import List, Dict, Any, Optional
-import math
-import asyncio
-from datetime import datetime, timezone
-from fiber.logging_utils import get_logger
+from typing import Dict, Any, Optional
+from ..decorators import task_timer
+from .inputs import Inputs
+from .outputs import Outputs
 
-logger = get_logger(__name__)
 
 class ScoringMechanism(BaseModel, ABC):
-    """
-    Base class for all scoring mechanisms.
+    """Base class for all scoring mechanisms.
 
-    Provides a modular interface for scoring tasks with shared methods for:
-    - Score calculation
-    - Normalization
-    - Prediction and score saving
+    The ScoringMechanism base class represents the scoring mechanism of a subtask.
+    Should be extended to define specific scoring mechanisms for different subtasks, to be run by the validator.
 
-    Should be extended to define specific scoring mechanisms for different tasks.
+    - Inputs here are NOT the same as the inputs of the subtask. Rather, they are the inputs of the scoring mechanism (Ground Truth, API data, etc)
+
+    - Outputs ARE the the result of the subtask completed by the miner.
+
+    inputs: Dict[str, Any]
+    outputs: Dict[str, Any]
     """
 
     name: str = Field(..., description="Name of the scoring mechanism")
     description: str = Field(..., description="Description of how scoring works")
-    normalize_score: bool = Field(default=True, description="Whether to normalize the score")
+    normalize_score: bool = Field(
+        default=True, description="Whether to normalize the score"
+    )
     max_score: float = Field(default=100.0, description="Maximum possible score")
-    db_manager: Any = Field(default=None, description="Database manager for saving predictions and scores")
+
+    model_config = {"arbitrary_types_allowed": True}
 
     @abstractmethod
-    def calculate_score(self, predicted_value: float, actual_value: float) -> float:
+    @task_timer
+    def score(self, predictions: Any, ground_truth: Any) -> Dict[str, float]:
         """
-        Calculate the score for a single prediction.
-
-        Args:
-            predicted_value (float): The predicted value.
-            actual_value (float): The ground truth value.
-
-        Returns:
-            float: The calculated score.
+        Score the outputs of a subtask against ground truth.
+        Returns a dictionary of score metrics.
         """
         pass
-
-    def normalize_scores(self, scores: List[float]) -> List[float]:
-        """
-        Normalize scores to the range [0, 1].
-
-        Args:
-            scores (List[float]): List of raw scores.
-
-        Returns:
-            List[float]: Normalized scores.
-        """
-        valid_scores = [score for score in scores if not math.isnan(score)]
-
-        if not valid_scores:
-            logger.warning("All scores are NaN. Returning default normalized scores.")
-            return [0.0 for _ in scores]
-
-        min_score = min(valid_scores)
-        max_score = max(valid_scores)
-
-        if max_score == min_score:
-            return [1.0 for _ in scores]  # All valid scores are the same
-
-        return [(score - min_score) / (max_score - min_score) if not math.isnan(score) else 0.0 for score in scores]
-
-    async def save_predictions(self, predictions: List[Dict[str, Any]], table_name: str):
-        """
-        Save predictions to the specified database table.
-
-        Args:
-            predictions (List[Dict[str, Any]]): List of prediction dictionaries.
-            table_name (str): Name of the table to save predictions.
-        """
-        try:
-            query = f"""
-            INSERT INTO {table_name} (id, miner_uid, miner_hotkey, predicted_value, query_time, status)
-            VALUES (:id, :miner_uid, :miner_hotkey, :predicted_value, CURRENT_TIMESTAMP, 'pending')
-            ON CONFLICT (id) DO NOTHING
-            """
-            for prediction in predictions:
-                await self.db_manager.execute(query, prediction)
-            logger.info(f"Successfully saved {len(predictions)} predictions to {table_name}.")
-        except Exception as e:
-            logger.error(f"Error saving predictions to {table_name}: {e}")
-
-    async def save_scores(self, scores: List[Dict[str, Any]], table_name: str):
-        """
-        Save scores to the specified database table.
-
-        Args:
-            scores (List[Dict[str, Any]]): List of score dictionaries.
-            table_name (str): Name of the table to save scores.
-        """
-        try:
-            query = f"""
-            INSERT INTO {table_name} (miner_uid, miner_hotkey, query_time, predicted_value, ground_truth_value, score, scored_at)
-            VALUES (:miner_uid, :miner_hotkey, :query_time, :predicted_value, :ground_truth_value, :score, CURRENT_TIMESTAMP)
-            """
-            for score in scores:
-                await self.db_manager.execute(query, score)
-            logger.info(f"Successfully saved {len(scores)} scores to {table_name}.")
-        except Exception as e:
-            logger.error(f"Error saving scores to {table_name}: {e}")
-
-    async def score(self, predictions: List[Dict[str, Any]], ground_truth: float, prediction_table: str, score_table: str):
-        """
-        Score multiple predictions, normalize scores, and save them.
-
-        Args:
-            predictions (List[Dict[str, Any]]): List of prediction dictionaries containing:
-                - id
-                - miner_uid
-                - miner_hotkey
-                - predicted_value
-            ground_truth (float): The ground truth value.
-            prediction_table (str): Table name for saving predictions.
-            score_table (str): Table name for saving scores.
-
-        Returns:
-            List[Dict[str, Any]]: List of score dictionaries with scores and metadata.
-        """
-        try:
-            if not isinstance(predictions, list) or not isinstance(ground_truth, (int, float)):
-                raise ValueError("Invalid predictions or ground truth format.")
-
-            miner_scores = []
-            for prediction in predictions:
-                score_value = self.calculate_score(prediction["predicted_value"], ground_truth)
-                miner_scores.append({
-                    "miner_uid": prediction["miner_uid"],
-                    "miner_hotkey": prediction["miner_hotkey"],
-                    "query_time": prediction.get("query_time", datetime.now(timezone.utc)),
-                    "predicted_value": prediction["predicted_value"],
-                    "ground_truth_value": ground_truth,
-                    "score": score_value
-                })
-
-            # Save predictions
-            await self.save_predictions(predictions, prediction_table)
-
-            # Save scores
-            await self.save_scores(miner_scores, score_table)
-
-            return miner_scores
-        except Exception as e:
-            logger.error(f"Error in scoring process: {e}")
-            return []

--- a/gaia/tasks/defined_tasks/geomagnetic/geomagnetic_scoring_mechanism.py
+++ b/gaia/tasks/defined_tasks/geomagnetic/geomagnetic_scoring_mechanism.py
@@ -1,55 +1,169 @@
 from gaia.tasks.base.components.scoring_mechanism import ScoringMechanism
+from fiber.logging_utils import get_logger
+import math
+import asyncio
+from datetime import timezone
 
+logger = get_logger(__name__)
 
 class GeomagneticScoringMechanism(ScoringMechanism):
     """
-    Scoring mechanism for geomagnetic tasks.
+    Updated scoring mechanism for geomagnetic tasks.
 
-    This mechanism scores miner predictions based on the deviation
-    from the ground truth DST value.
+    Scores are now inverted, so higher scores represent better predictions.
+    Handles invalid scores (`NaN`) gracefully.
+    Includes functionality to capture and save miner predictions and scores.
     """
 
-    def __init__(self):
+    def __init__(self, db_manager):
         super().__init__(
             name="Geomagnetic Scoring",
-            description="Scoring mechanism for geomagnetic tasks based on deviation from ground truth.",
+            description="Updated scoring mechanism for geomagnetic tasks with improved normalization.",
         )
+        self.db_manager = db_manager
 
     def calculate_score(self, predicted_value, actual_value):
         """
-        Calculates the score for a miner's prediction based on deviation.
+        Calculates the score for a miner's prediction based on the deviation from ground truth.
 
         Args:
             predicted_value (float): The predicted DST value from the miner.
-            actual_value (int): The ground truth DST value.
+            actual_value (float): The ground truth DST value.
 
         Returns:
-            float: The absolute deviation between the predicted value and the ground truth.
+            float: A higher score indicates a better prediction.
         """
-        if not isinstance(predicted_value, (int, float)):
-            raise ValueError("Predicted value must be an integer or a float.")
-        if not isinstance(actual_value, int):
-            raise ValueError("Actual value must be an integer.")
+        if not isinstance(predicted_value, (int, float)) or not isinstance(actual_value, (int, float)):
+            return float("nan")  # Invalid predictions are marked as NaN
 
-        # Calculate the absolute deviation
-        score = abs(predicted_value - actual_value)
-        return score
+        try:
+            # Higher score for smaller deviation
+            return 1 / (1 + abs(predicted_value - actual_value))
+        except Exception as e:
+            logger.error(f"Error calculating score: {e}")
+            return float("nan")
 
-    def score(self, predictions, ground_truth):
+    def normalize_scores(self, scores):
         """
-        Scores multiple predictions against the ground truth.
+        Normalizes scores to the range [0, 1].
 
         Args:
-            predictions (list[float]): List of predicted values from miners.
-            ground_truth (int): The ground truth DST value.
+            scores (list[float]): List of raw scores.
 
         Returns:
-            list[float]: List of scores for each prediction.
+            list[float]: Normalized scores.
         """
-        if not isinstance(predictions, list):
-            raise ValueError("Predictions must be a list of float or int values.")
-        if not isinstance(ground_truth, int):
-            raise ValueError("Ground truth must be an integer.")
+        valid_scores = [score for score in scores if not math.isnan(score)]
 
-        # Calculate scores for all predictions
-        return [self.calculate_score(pred, ground_truth) for pred in predictions]
+        if not valid_scores:
+            logger.warning("All scores are NaN. Returning default normalized scores.")
+            return [0.0 for _ in scores]
+
+        min_score = min(valid_scores)
+        max_score = max(valid_scores)
+
+        if max_score == min_score:
+            return [1.0 for _ in scores]  # All valid scores are the same
+
+        return [(score - min_score) / (max_score - min_score) if not math.isnan(score) else 0.0 for score in scores]
+
+    async def save_predictions(self, miner_predictions):
+        """
+        Save miner predictions to the geomagnetic_predictions table.
+
+        Args:
+            miner_predictions (list[dict]): List of miner prediction dictionaries containing:
+                - miner_uid
+                - miner_hotkey
+                - predicted_value
+        """
+        try:
+            query = """
+            INSERT INTO geomagnetic_predictions (id, miner_uid, miner_hotkey, predicted_value, query_time, status)
+            VALUES (:id, :miner_uid, :miner_hotkey, :predicted_value, CURRENT_TIMESTAMP, 'pending')
+            ON CONFLICT (id) DO NOTHING
+            """
+            for prediction in miner_predictions:
+                await self.db_manager.execute(query, {
+                    "id": prediction["id"],
+                    "miner_uid": prediction["miner_uid"],
+                    "miner_hotkey": prediction["miner_hotkey"],
+                    "predicted_value": prediction["predicted_value"]
+                })
+            logger.info(f"Successfully saved {len(miner_predictions)} predictions.")
+        except Exception as e:
+            logger.error(f"Error saving predictions to the database: {e}")
+
+    async def save_scores(self, miner_scores):
+        """
+        Save miner scores to the geomagnetic_history table.
+
+        Args:
+            miner_scores (list[dict]): List of miner score dictionaries containing:
+                - miner_uid
+                - miner_hotkey
+                - query_time
+                - predicted_value
+                - ground_truth_value
+                - score
+        """
+        try:
+            query = """
+            INSERT INTO geomagnetic_history (miner_uid, miner_hotkey, query_time, predicted_value, ground_truth_value, score, scored_at)
+            VALUES (:miner_uid, :miner_hotkey, :query_time, :predicted_value, :ground_truth_value, :score, CURRENT_TIMESTAMP)
+            """
+            for score in miner_scores:
+                await self.db_manager.execute(query, {
+                    "miner_uid": score["miner_uid"],
+                    "miner_hotkey": score["miner_hotkey"],
+                    "query_time": score["query_time"],
+                    "predicted_value": score["predicted_value"],
+                    "ground_truth_value": score["ground_truth_value"],
+                    "score": score["score"]
+                })
+            logger.info(f"Successfully saved {len(miner_scores)} scores.")
+        except Exception as e:
+            logger.error(f"Error saving scores to the database: {e}")
+
+    async def score(self, predictions, ground_truth):
+        """
+        Scores multiple predictions against the ground truth and saves both predictions and scores.
+
+        Args:
+            predictions (list[dict]): List of prediction dictionaries containing:
+                - id
+                - miner_uid
+                - miner_hotkey
+                - predicted_value
+            ground_truth (float): The ground truth DST value.
+
+        Returns:
+            list[dict]: List of score dictionaries with scores and additional metadata.
+        """
+        try:
+            if not isinstance(predictions, list) or not isinstance(ground_truth, (int, float)):
+                raise ValueError("Invalid predictions or ground truth format.")
+
+            miner_scores = []
+            for prediction in predictions:
+                score_value = self.calculate_score(prediction["predicted_value"], ground_truth)
+                miner_scores.append({
+                    "miner_uid": prediction["miner_uid"],
+                    "miner_hotkey": prediction["miner_hotkey"],
+                    "query_time": prediction.get("query_time", datetime.now(timezone.utc)),
+                    "predicted_value": prediction["predicted_value"],
+                    "ground_truth_value": ground_truth,
+                    "score": score_value
+                })
+
+            # Save predictions to the database
+            await self.save_predictions(predictions)
+
+            # Save scores to the database
+            await self.save_scores(miner_scores)
+
+            return miner_scores
+        except Exception as e:
+            logger.error(f"Error in scoring process: {e}")
+            return []
+

--- a/gaia/tasks/defined_tasks/geomagnetic/geomagnetic_task.py
+++ b/gaia/tasks/defined_tasks/geomagnetic/geomagnetic_task.py
@@ -83,11 +83,10 @@ class GeomagneticTask(Task):
             metadata=GeomagneticMetadata(),
             inputs=GeomagneticInputs(),
             outputs=GeomagneticOutputs(),
-            scoring_mechanism=GeomagneticScoringMechanism(),
+            db_manager=db_manager,
+            scoring_mechanism=GeomagneticScoringMechanism(db_manager=db_manager),
             **data,
         )
-        if db_manager:
-            self.db_manager = db_manager
 
         # Try to load custom model first
         try:
@@ -232,6 +231,10 @@ class GeomagneticTask(Task):
         self, validator, timestamp, dst_value, historical_data, current_hour_start
     ):
         """Query miners with current data and process responses."""
+        if timestamp == "N/A" or dst_value == "N/A":
+            logger.warning("Invalid geomagnetic data. Skipping miner queries.")
+            return
+
         # Construct Payload for Miners
         nonce = str(uuid4())
 

--- a/gaia/tasks/defined_tasks/soilmoisture/schema.json
+++ b/gaia/tasks/defined_tasks/soilmoisture/schema.json
@@ -37,7 +37,9 @@
             "created_at": "TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP",
             "sentinel_bounds": "FLOAT[]",
             "sentinel_crs": "INTEGER",
-            "status": "TEXT NOT NULL DEFAULT 'pending'"
+            "status": "TEXT NOT NULL DEFAULT 'sent_to_miner'",
+            "retry_count": "INTEGER DEFAULT 0",
+            "next_retry_time": "TIMESTAMP WITH TIME ZONE"
         },
         "indexes": [
             {"column": "region_id", "unique": false},

--- a/gaia/tasks/defined_tasks/soilmoisture/utils/smap_api.py
+++ b/gaia/tasks/defined_tasks/soilmoisture/utils/smap_api.py
@@ -49,6 +49,7 @@ def construct_smap_url(datetime_obj):
     Construct URL for SMAP L4 Global Product data
     Example: SMAP_L4_SM_gph_20241111T013000_Vv7031_001.h5
     """
+    #datetime_obj = datetime_obj - timedelta(days=7) #this is for testing
     valid_time = get_valid_smap_time(datetime_obj)
     date_dir = valid_time.strftime("%Y.%m.%d")
     file_date = valid_time.strftime("%Y%m%d")

--- a/gaia/validator/validator.py
+++ b/gaia/validator/validator.py
@@ -9,7 +9,10 @@ from typing import Any, Optional, List, Dict
 from dotenv import load_dotenv
 from cryptography.fernet import Fernet
 import httpx
-from fiber.chain import chain_utils
+from fiber.chain import chain_utils, interface
+from fiber.chain import weights as w
+from fiber.chain.fetch_nodes import get_nodes_for_netuid
+from fiber.chain.chain_utils import query_substrate
 from fiber.logging_utils import get_logger
 from fiber.encrypted.validator import client as vali_client, handshake
 from fiber.chain.metagraph import Metagraph
@@ -273,212 +276,59 @@ class GaiaValidator:
             await asyncio.sleep(300)
 
     async def main_scoring(self):
-        """
-        Run scoring every 300 blocks, with weight setting 50 blocks after scoring.
-        """
+        """Run scoring every subnet tempo blocks."""
+        weight_setter = FiberWeightSetter(
+            netuid=self.netuid,
+            wallet_name=self.wallet_name,
+            hotkey_name=self.hotkey_name,
+            network=self.subtensor_network,
+        )
+
         while True:
             try:
-                self.metagraph.sync_nodes()
-                block = self.substrate.get_block()
-                self.current_block = block["header"]["number"]
+
+                validator_uid = self.substrate.query(
+                    "SubtensorModule", 
+                    "Uids", 
+                    [self.netuid, self.keypair.ss58_address]
+                ).value
                 
-                next_weight_block = ((self.current_block // 300) * 300) + 50
-                blocks_until_weights = next_weight_block - self.current_block
-                
-                logger.info(f"Fetched current block: {self.current_block}")
-                logger.info(f"Next weight setting at block: {next_weight_block}")
-                
-                await asyncio.sleep(30)
+                if validator_uid is None:
+                    logger.error("Validator not found on chain")
+                    await asyncio.sleep(12)
+                    continue
 
-                if self.current_block >= next_weight_block:
-                    logger.info("Syncing metagraph nodes...")
-                    self.metagraph.sync_nodes()
-                    logger.info("Metagraph synced. Fetching recent scores...")
+                blocks_since_update = w.blocks_since_last_update(
+                    self.substrate, 
+                    self.netuid, 
+                    validator_uid
+                )
+                min_interval = w.min_interval_to_set_weights(
+                    self.substrate, 
+                    self.netuid
+                )
 
-                    three_days_ago = datetime.now(timezone.utc) - timedelta(days=3)
-                    
-                    query = """
-                    SELECT score 
-                    FROM score_table 
-                    WHERE task_name = :task_name
-                    AND created_at >= :start_time
-                    ORDER BY created_at DESC 
-                    LIMIT 1
-                    """
-                    
-                    geomagnetic_result = await self.database_manager.fetch_one(
-                        query, 
-                        {"task_name": "geomagnetic", "start_time": three_days_ago}
-                    )
-                    soil_result = await self.database_manager.fetch_one(
-                        query,
-                        {"task_name": "soil_moisture", "start_time": three_days_ago}
-                    )
-
-                    geomagnetic_scores = geomagnetic_result["score"] if geomagnetic_result else [float("nan")] * 256
-                    soil_scores = soil_result["score"] if soil_result else [float("nan")] * 256
-
-                    logger.info("Recent scores fetched. Calculating aggregate scores...")
-
-                    weights = [0.0] * 256
-                    for idx in range(256):
-                        geomagnetic_score = geomagnetic_scores[idx]
-                        soil_score = soil_scores[idx]
-
-                        if math.isnan(geomagnetic_score) and math.isnan(soil_score):
-                            weights[idx] = 0.0
-                            logger.debug(f"Both scores nan - setting weight to 0")
-                        elif math.isnan(geomagnetic_score):
-                            weights[idx] = 0.5 * soil_score
-                            logger.debug(
-                                f"Geo score nan - using soil score: {weights[idx]}"
-                            )
-                        elif math.isnan(soil_score):
-                            geo_normalized = math.exp(-abs(geomagnetic_score) / 10)
-                            weights[idx] = 0.5 * geo_normalized
-                            logger.debug(
-                                f"UID {idx}: Soil score nan - normalized geo score: {geo_normalized} -> weight: {weights[idx]}"
-                            )
-                        else:
-                            geo_normalized = math.exp(-abs(geomagnetic_score) / 10)
-                            weights[idx] = (0.5 * geo_normalized) + (0.5 * soil_score)
-                            logger.debug(
-                                f"UID {idx}: Both scores valid - geo_norm: {geo_normalized}, soil: {soil_score} -> weight: {weights[idx]}"
-                            )
-
-                        logger.info(
-                            f"UID {idx}: geo={geomagnetic_score} (norm={geo_normalized if 'geo_normalized' in locals() else 'nan'}), soil={soil_score}, weight={weights[idx]}"
-                        )
-
-                    logger.info(f"Weights before normalization: {weights}")
-
-                    non_zero_weights = [w for w in weights if w != 0.0]
-                    if non_zero_weights:
-                        # Sort indices by weight for ranking (negative scores = higher error = lower rank)
-                        sorted_indices = sorted(
-                            range(len(weights)),
-                            key=lambda k: (
-                                weights[k] if weights[k] != 0.0 else float("-inf")
-                            ),
-                        )
-
-                        new_weights = [0.0] * len(weights)
-                        for rank, idx in enumerate(sorted_indices):
-                            if weights[idx] != 0.0:
-                                try:
-                                    normalized_rank = 1.0 - (rank / len(non_zero_weights))
-                                    exponent = max(
-                                        min(-20 * (normalized_rank - 0.5), 709), -709
-                                    )
-                                    new_weights[idx] = 1 / (1 + math.exp(exponent))
-                                except OverflowError:
-                                    logger.warning(
-                                        f"Overflow prevented for rank {rank}, idx {idx}"
-                                    )
-
-                                    if normalized_rank > 0.5:
-                                        new_weights[idx] = 1.0
-                                    else:
-                                        new_weights[idx] = 0.0
-
-
-                        total = sum(new_weights)
-                        if total > 0:
-                            self.weights = [w / total for w in new_weights]
-
-                            top_20_weight = sum(
-                                sorted(self.weights, reverse=True)[
-                                    : int(len(weights) * 0.2)
-                                ]
-                            )
-                            logger.info(
-                                f"Weight distribution: top 20% of nodes hold {top_20_weight*100:.1f}% of total weight"
-                            )
-
-                            logger.info("Attempting to set weights...")
-                            success = await self.set_weights(self.weights)
+                if (min_interval is None or 
+                    (blocks_since_update is not None and blocks_since_update >= min_interval)):
+                    if w.can_set_weights(self.substrate, self.netuid, validator_uid):
+                        normalized_weights = await self._calc_task_weights()
+                        if normalized_weights:
+                            success = await weight_setter.set_weights(normalized_weights)
                             if success:
-                                if self.current_block == self.last_set_weights_block:
-                                    logger.info(f"Successfully set weights at block {self.current_block}")
-                                else:
-                                    logger.info("Waiting for next weight setting interval")
-                            else:
-                                logger.error(f"Error setting weights at block {self.current_block}")
-                        else:
-                            logger.warning("No positive weights after normalization")
-                    else:
-                        logger.warning(
-                            "All weights are zero or nan, skipping weight setting"
-                        )
+                                await self.update_last_weights_block()
+                                logger.info("✅ Successfully set weights")
+                                await asyncio.sleep(30)
+                else:
+                    logger.info(
+                        f"Waiting for weight setting: {blocks_since_update}/{min_interval} blocks"
+                    )
+
+                await asyncio.sleep(12)
 
             except Exception as e:
                 logger.error(f"Error in main_scoring: {e}")
                 logger.error(traceback.format_exc())
-                await asyncio.sleep(60)
-
-    async def set_weights(self, weights: List[float], timeout: int = 30, max_retries: int = 3) -> bool:
-        """
-        Set weights on the chain with timeout and retry logic.
-
-        Args:
-            weights (List[float]): List of weights aligned with UIDs.
-            timeout (int): Maximum time to wait for the operation (in seconds).
-            max_retries (int): Maximum number of retries if the operation fails.
-
-        Returns:
-            bool: True if weights were set successfully, False otherwise.
-        """
-        try:
-            block = self.substrate.get_block()
-            self.current_block = block["header"]["number"]
-
-            if self.last_set_weights_block:
-                blocks_since_last = self.current_block - self.last_set_weights_block
-                if blocks_since_last < 300:
-                    blocks_remaining = 300 - blocks_since_last
-                    next_block = self.last_set_weights_block + 300
-                    logger.info(f"Waiting for block interval - {blocks_remaining} blocks remaining")
-                    logger.info(f"Last set: block {self.last_set_weights_block}")
-                    logger.info(f"Next possible: block {next_block} (current: {self.current_block})")
-                    return True
-
-            weight_setter = FiberWeightSetter(
-                netuid=self.netuid,
-                wallet_name=self.wallet_name,
-                hotkey_name=self.hotkey_name,
-                network=self.subtensor_network,
-                last_set_block=self.last_set_weights_block,
-                current_block=self.current_block
-            )
-
-            attempt = 0
-            delay = 1
-            while attempt < max_retries:
-                try:
-                    success = await asyncio.wait_for(weight_setter.set_weights(weights), timeout=timeout)
-                    if success:
-                        self.last_set_weights_block = self.current_block
-                        logger.info(f"✅ Successfully set weights at block {self.current_block}")
-                        logger.info(f"Next weight set possible at block {self.current_block + 300}")
-                        return True
-                    else:
-                        logger.warning("❌ Failed to set weights, retrying...")
-                except asyncio.TimeoutError:
-                    logger.debug(f"⏳ Timeout occurred while setting weights (attempt {attempt + 1}/{max_retries})")
-                except Exception as e:
-                    logger.error(f"❌ Error during weight setting (attempt {attempt + 1}/{max_retries}): {e}")
-                    logger.error(traceback.format_exc())
-
-                attempt += 1
-                await asyncio.sleep(delay)
-                delay = min(delay * 2, 10)
-
-            return False
-
-        except Exception as e:
-            logger.error(f"Unexpected error in set_weights: {e}")
-            logger.error(traceback.format_exc())
-            return False
+                await asyncio.sleep(12)
 
     async def status_logger(self):
         """Log the status of the validator periodically."""
@@ -611,6 +461,97 @@ class GaiaValidator:
                 logger.error(traceback.format_exc())
             finally:
                 await asyncio.sleep(60)
+
+    async def _calc_task_weights(self) -> Optional[List[float]]:
+        """Calculate and normalize weights from task scores."""
+        logger.info("Syncing metagraph nodes...")
+        self.metagraph.sync_nodes()
+        logger.info("Metagraph synced. Fetching recent scores...")
+
+        three_days_ago = datetime.now(timezone.utc) - timedelta(days=3)
+        
+        query = """
+        SELECT score 
+        FROM score_table 
+        WHERE task_name = :task_name
+        AND created_at >= :start_time
+        ORDER BY created_at DESC 
+        LIMIT 1
+        """
+        
+        geomagnetic_result = await self.database_manager.fetch_one(
+            query, {"task_name": "geomagnetic", "start_time": three_days_ago}
+        )
+        soil_result = await self.database_manager.fetch_one(
+            query, {"task_name": "soil_moisture", "start_time": three_days_ago}
+        )
+
+        geomagnetic_scores = geomagnetic_result["score"] if geomagnetic_result else [float("nan")] * 256
+        soil_scores = soil_result["score"] if soil_result else [float("nan")] * 256
+
+        logger.info("Recent scores fetched. Calculating aggregate scores...")
+
+        weights = [0.0] * 256
+        for idx in range(256):
+            geomagnetic_score = geomagnetic_scores[idx]
+            soil_score = soil_scores[idx]
+
+            if math.isnan(geomagnetic_score) and math.isnan(soil_score):
+                weights[idx] = 0.0
+                logger.debug(f"Both scores nan - setting weight to 0")
+            elif math.isnan(geomagnetic_score):
+                weights[idx] = 0.5 * soil_score
+                logger.debug(f"Geo score nan - using soil score: {weights[idx]}")
+            elif math.isnan(soil_score):
+                geo_normalized = math.exp(-abs(geomagnetic_score) / 10)
+                weights[idx] = 0.5 * geo_normalized
+                logger.debug(f"UID {idx}: Soil score nan - normalized geo score: {geo_normalized} -> weight: {weights[idx]}")
+            else:
+                geo_normalized = math.exp(-abs(geomagnetic_score) / 10)
+                weights[idx] = (0.5 * geo_normalized) + (0.5 * soil_score)
+                logger.debug(f"UID {idx}: Both scores valid - geo_norm: {geo_normalized}, soil: {soil_score} -> weight: {weights[idx]}")
+
+            logger.info(f"UID {idx}: geo={geomagnetic_score} (norm={geo_normalized if 'geo_normalized' in locals() else 'nan'}), soil={soil_score}, weight={weights[idx]}")
+
+        logger.info(f"Weights before normalization: {weights}")
+
+        non_zero_weights = [w for w in weights if w != 0.0]
+        if non_zero_weights:
+            sorted_indices = sorted(
+                range(len(weights)),
+                key=lambda k: (weights[k] if weights[k] != 0.0 else float("-inf")),
+            )
+
+            new_weights = [0.0] * len(weights)
+            for rank, idx in enumerate(sorted_indices):
+                if weights[idx] != 0.0:
+                    try:
+                        normalized_rank = 1.0 - (rank / len(non_zero_weights))
+                        exponent = max(min(-20 * (normalized_rank - 0.5), 709), -709)
+                        new_weights[idx] = 1 / (1 + math.exp(exponent))
+                    except OverflowError:
+                        logger.warning(f"Overflow prevented for rank {rank}, idx {idx}")
+                        if normalized_rank > 0.5:
+                            new_weights[idx] = 1.0
+                        else:
+                            new_weights[idx] = 0.0
+
+            total = sum(new_weights)
+            if total > 0:
+                return [w / total for w in new_weights]
+            else:
+                logger.warning("No positive weights after normalization")
+                return None
+        else:
+            logger.warning("All weights are zero or nan, skipping weight setting")
+            return None
+
+    async def update_last_weights_block(self):
+        try:
+            block = self.substrate.get_block()
+            self.last_set_weights_block = block["header"]["number"]
+        except Exception as e:
+            logger.error(f"Error updating last weights block: {e}")
 
 
 if __name__ == "__main__":

--- a/gaia/validator/validator.py
+++ b/gaia/validator/validator.py
@@ -267,7 +267,7 @@ class GaiaValidator:
                     asyncio.create_task(self.status_logger()),
                     asyncio.create_task(self.main_scoring()),
                     asyncio.create_task(self.handle_miner_deregistration_loop()),
-                   # asyncio.create_task(self.check_for_updates()),
+                    asyncio.create_task(self.check_for_updates()),
                 ]
 
                 await asyncio.gather(*workers, return_exceptions=True)

--- a/gaia/validator/validator.py
+++ b/gaia/validator/validator.py
@@ -11,7 +11,7 @@ from cryptography.fernet import Fernet
 import httpx
 from fiber.chain import chain_utils
 from fiber.logging_utils import get_logger
-from fiber.validator import client as vali_client, handshake
+from fiber.validator import client as vali_client
 from fiber.chain.metagraph import Metagraph
 from substrateinterface import SubstrateInterface
 from gaia.tasks.defined_tasks.geomagnetic.geomagnetic_task import GeomagneticTask
@@ -147,45 +147,30 @@ class GaiaValidator:
                 base_url = f"https://{node.ip}:{node.port}"
 
                 try:
-                    symmetric_key_str, symmetric_key_uuid = (
-                        await handshake.perform_handshake(
-                            keypair=self.keypair,
-                            httpx_client=self.httpx_client,
-                            server_address=base_url,
-                            miner_hotkey_ss58_address=miner_hotkey,
-                        )
-                    )
-
-                    if symmetric_key_str and symmetric_key_uuid:
-                        logger.info(f"Handshake successful with miner {miner_hotkey}")
-                        fernet = Fernet(symmetric_key_str)
-
-                        resp = await vali_client.make_non_streamed_post(
-                            httpx_client=self.httpx_client,
-                            server_address=base_url,
-                            fernet=fernet,
-                            keypair=self.keypair,
-                            symmetric_key_uuid=symmetric_key_uuid,
-                            validator_ss58_address=self.keypair.ss58_address,
-                            miner_ss58_address=miner_hotkey,
-                            payload=payload,
+                    async with vali_client.create_client(
+                        keypair=self.keypair,
+                        server_url=base_url,
+                        miner_hotkey=miner_hotkey
+                    ) as client:
+                        logger.info(f"Established connection with miner {miner_hotkey}")
+                        
+                        resp = await client.post(
                             endpoint=endpoint,
+                            payload=payload
                         )
 
-                        # resp.raise_for_status()
-                        # logger.debug(f"Response from miner {miner_hotkey}: {resp}")
-                        # logger.debug(f"Response text from miner {miner_hotkey}: {resp.headers}")
-                        # Create a dictionary with both response text and metadata
-                        response_data = {
-                            "text": resp.text,
-                            "hotkey": miner_hotkey,
-                            "port": node.port,
-                            "ip": node.ip,
-                        }
-                        responses[miner_hotkey] = response_data
-                        logger.info(f"Completed request to {miner_hotkey}")
-                    else:
-                        logger.warning(f"Failed handshake with miner {miner_hotkey}")
+                    # resp.raise_for_status()
+                    # logger.debug(f"Response from miner {miner_hotkey}: {resp}")
+                    # logger.debug(f"Response text from miner {miner_hotkey}: {resp.headers}")
+                    # Create a dictionary with both response text and metadata
+                    response_data = {
+                        "text": resp.text,
+                        "hotkey": miner_hotkey,
+                        "port": node.port,
+                        "ip": node.ip,
+                    }
+                    responses[miner_hotkey] = response_data
+                    logger.info(f"Completed request to {miner_hotkey}")
                 except httpx.HTTPStatusError as e:
                     logger.warning(f"HTTP error from miner {miner_hotkey}: {e}")
                     # logger.debug(f"Error details: {traceback.format_exc()}")
@@ -266,7 +251,7 @@ class GaiaValidator:
                     asyncio.create_task(self.status_logger()),
                     asyncio.create_task(self.main_scoring()),
                     asyncio.create_task(self.handle_miner_deregistration_loop()),
-                    asyncio.create_task(self.check_for_updates()),
+                   # asyncio.create_task(self.check_for_updates()),
                 ]
 
                 await asyncio.gather(*workers, return_exceptions=True)

--- a/gaia/validator/weights/set_weights.py
+++ b/gaia/validator/weights/set_weights.py
@@ -18,50 +18,26 @@ class FiberWeightSetter:
         wallet_name: str = "default",
         hotkey_name: str = "default",
         network: str = "finney",
-        last_set_block: int = None,
-        current_block: int = None,
         timeout: int = 30,
-        max_retries: int = 3,
     ):
-        """
-        Initialize the weight setter with fiber instead of bittensor
-        """
+        """Initialize the weight setter with fiber"""
         self.netuid = netuid
-        self.wallet_name = wallet_name
-        self.hotkey_name = hotkey_name
         self.network = network
         self.substrate = interface.get_substrate(subtensor_network=network)
         self.keypair = chain_utils.load_hotkey_keypair(
             wallet_name=wallet_name, hotkey_name=hotkey_name
         )
-        self.last_set_block = last_set_block
-        self.current_block = current_block
         self.timeout = timeout
-        self.max_retries = max_retries
 
-    def is_time_to_set_weights(self) -> bool:
-        """Check if enough blocks have passed since last weight setting."""
-        if self.last_set_block is None:
-            return True
-        
-        blocks_since_last = self.current_block - self.last_set_block
-        if blocks_since_last < 300:
-            logger.debug(f"Next weight set possible at block {self.last_set_block + 300}")
-            return False
-        
-        if blocks_since_last < 305:
-            return False
-        
-        return True
-
-    def calculate_weights(self, n_nodes: int, weights: List[float] = None) -> torch.Tensor:
-        """Convert input weights to normalized tensor."""
+    def calculate_weights(self, weights: List[float] = None) -> torch.Tensor:
+        """Convert input weights to normalized tensor with min/max bounds"""
         if weights is None:
             logger.warning("No weights provided")
             return None
 
         nodes = get_nodes_for_netuid(substrate=self.substrate, netuid=self.netuid)
         node_ids = [node.node_id for node in nodes]
+
         aligned_weights = [
             max(0.0, weights[node_id]) if node_id < len(weights) else 0.0
             for node_id in node_ids
@@ -75,13 +51,12 @@ class FiberWeightSetter:
             return None
 
         weights_tensor /= weights_tensor.sum()
-
         min_weight = 1.0 / (2 * active_nodes)
         max_weight = 0.5  # Maximum 50% weight for any node
 
         mask = weights_tensor > 0
         weights_tensor[mask] = torch.clamp(weights_tensor[mask], min_weight, max_weight)
-        weights_tensor /= weights_tensor.sum()  # Renormalize
+        weights_tensor /= weights_tensor.sum()
 
         logger.info(
             f"Weight distribution stats:"
@@ -91,86 +66,69 @@ class FiberWeightSetter:
             f"\n- Total weight: {weights_tensor.sum().item():.4f}"
         )
 
-        return weights_tensor
-
-    def find_validator_uid(self, nodes) -> int:
-        """Find the validator's UID from the list of nodes."""
-        for node in nodes:
-            if node.hotkey == self.keypair.ss58_address:
-                return node.node_id
-        logger.info("❗Validator not found in nodes list")
-        return None
+        return weights_tensor, node_ids
 
     async def set_weights(self, weights: List[float] = None) -> bool:
+        """Set weights on chain"""
         try:
             if weights is None:
                 logger.info("No weights provided - skipping weight setting")
                 return False
 
-            logger.info(f"\nAttempting to set weights for subnet {self.netuid}...")
+            logger.info(f"\nSetting weights for subnet {self.netuid}...")
             
-            if not self.is_time_to_set_weights():
-                blocks_remaining = 300 - (self.current_block - self.last_set_block)
-                logger.info(f"Too soon to set weights. Wait {blocks_remaining} more blocks.")
-                logger.info(f"Next possible at block {self.last_set_block + 300}")
-                return True 
-
+            self.substrate = interface.get_substrate(subtensor_network=self.network)
             nodes = get_nodes_for_netuid(substrate=self.substrate, netuid=self.netuid)
-            if not nodes:
-                logger.error(f"❗No nodes found for subnet {self.netuid}")
-                return False
+            logger.info(f"Found {len(nodes)} nodes in subnet")
 
-            validator_uid = self.find_validator_uid(nodes)
+            validator_uid = self.substrate.query(
+                "SubtensorModule", 
+                "Uids", 
+                [self.netuid, self.keypair.ss58_address]
+            ).value
+            
+            version_key = self.substrate.query(
+                "SubtensorModule", 
+                "WeightsVersionKey", 
+                [self.netuid]
+            ).value
+            
             if validator_uid is None:
-                logger.error("❗Failed to get validator UID")
+                logger.error("❗Validator not found in nodes list")
                 return False
 
-            calculated_weights = self.calculate_weights(len(nodes), weights)
+            calculated_weights, node_ids = self.calculate_weights(weights)
             if calculated_weights is None:
-                logger.info("No valid weights to set")
                 return False
-
-            node_ids = [node.node_id for node in nodes]
-            logger.info("Setting weights on chain...")
 
             try:
-                result = await asyncio.wait_for(
-                    self._async_set_node_weights(
-                        substrate=self.substrate,
-                        keypair=self.keypair,
-                        node_ids=node_ids,
-                        node_weights=calculated_weights.tolist(),
-                        netuid=self.netuid,
-                        validator_node_id=validator_uid,
-                        wait_for_inclusion=True,
-                        wait_for_finalization=True,
-                    ),
-                    timeout=self.timeout
+                await self._async_set_node_weights(
+                    substrate=self.substrate,
+                    keypair=self.keypair,
+                    node_ids=[node.node_id for node in nodes],
+                    node_weights=calculated_weights.tolist(),
+                    netuid=self.netuid,
+                    validator_node_id=validator_uid,
+                    version_key=version_key,
+                    wait_for_inclusion=False,
+                    wait_for_finalization=False,
                 )
-
-                if result:
-                    logger.info("✅ Successfully set weights and finalized")
-                    self.last_set_block = self.current_block
-                    return True
-                return False
+                logger.info("Weight commit initiated, continuing...")
+                return True
 
             except Exception as e:
-                logger.error(f"##Error setting weights: {str(e)}")
-                logger.error(traceback.format_exc())
+                logger.error(f"Error initiating weight commit: {str(e)}")
                 return False
 
         except Exception as e:
-            logger.error(f"❗#Error in weight setting: {str(e)}")
+            logger.error(f"Error in weight setting: {str(e)}")
             logger.error(traceback.format_exc())
             return False
 
     async def _async_set_node_weights(self, **kwargs):
         """Async wrapper for the synchronous set_node_weights function"""
         loop = asyncio.get_event_loop()
-        return await loop.run_in_executor(
-            None,
-            lambda: w.set_node_weights(**kwargs)
-        )
+        return await loop.run_in_executor(None, lambda: w.set_node_weights(**kwargs))
 
 async def main():
     try:

--- a/gaia/validator/weights/set_weights.py
+++ b/gaia/validator/weights/set_weights.py
@@ -110,7 +110,7 @@ class FiberWeightSetter:
                     netuid=self.netuid,
                     validator_node_id=validator_uid,
                     version_key=version_key,
-                    wait_for_inclusion=False,
+                    wait_for_inclusion=True,
                     wait_for_finalization=False,
                 )
                 logger.info("Weight commit initiated, continuing...")

--- a/requirements.txt
+++ b/requirements.txt
@@ -132,6 +132,6 @@ websocket-client==1.8.0
 xarray==2024.7.0
 xxhash==3.5.0
 yarl==1.17.2
-fiber[full] @ git+https://github.com/rayonlabs/fiber.git@1.0.0
+fiber[full] @ git+https://github.com/rayonlabs/fiber.git@production
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,6 +41,7 @@ frozenlist==1.5.0
 fsspec==2024.10.0
 h11==0.14.0
 h3==4.1.2
+h5netcdf==1.4.1
 httpcore==1.0.6
 httpx==0.27.0
 huggingface-hub==0.26.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = gaia
-version = 1.0.1
-database_version = 1.0.0
+version = 1.0.2
+database_version = 1.0.1
 author = geardici, oneandahalfcats, qucat, gabby
 organization = Nickel5
 description = This project implements the Gaia subnet for Bittensor


### PR DESCRIPTION
Gaia 1.0.2 Update (2024-12-31)
CR3 Is now enabled!


## Fiber version 2 and CR3
- Migrated to fiber 2.1.0 maintaining encrypted data handling
- Enabled CR3

##  Bug Fixes
- Fixed inconsistent weight setting
- Resolved redundant retry checks in SMAP download process
- Tweaked Geomagnetic scoring, higher score means smaller deviation from ground truth
- Added SMAP retry mechanism, with 5 day retry limit
- Better handling when soil predictions are an invalid array shape

## Database Updates
- Added new columns to soil_moisture_predictions:
  - retry_count (INTEGER, default: 0)
  - next_retry_time (TIMESTAMP WITH TIME ZONE)
  - status updates for retry tracking
- Added index for next_retry_time to improve query performance

