### PR TITLE
v1.1.3 scoring patch

### DIFF
--- a/gaia/scoring/scoring.py
+++ b/gaia/scoring/scoring.py
@@ -36,11 +36,11 @@ class Scoring:
             if math.isnan(geo_score) and math.isnan(soil_score):
                 weights[idx] = 0.0
             elif math.isnan(geo_score):
-                weights[idx] = 0.5 * soil_score
+                weights[idx] = 0.75 * soil_score
             elif math.isnan(soil_score):
-                weights[idx] = 0.5 * math.exp(-abs(geo_score) / 10)
+                weights[idx] = 0.25 * math.exp(-abs(geo_score) / 10)
             else:
                 geo_normalized = math.exp(-abs(geo_score) / 10)
-                weights[idx] = 0.5 * geo_normalized + 0.5 * soil_score
+                weights[idx] = 0.25 * geo_normalized + 0.75 * soil_score
                 
         return weights

--- a/gaia/scoring/scoring.py
+++ b/gaia/scoring/scoring.py
@@ -36,11 +36,11 @@ class Scoring:
             if math.isnan(geo_score) and math.isnan(soil_score):
                 weights[idx] = 0.0
             elif math.isnan(geo_score):
-                weights[idx] = 0.75 * soil_score
+                weights[idx] = 0.60 * soil_score
             elif math.isnan(soil_score):
-                weights[idx] = 0.25 * math.exp(-abs(geo_score) / 10)
+                weights[idx] = 0.40 * math.exp(-abs(geo_score) / 10)
             else:
                 geo_normalized = math.exp(-abs(geo_score) / 10)
-                weights[idx] = 0.25 * geo_normalized + 0.75 * soil_score
+                weights[idx] = 0.40 * geo_normalized + 0.60 * soil_score
                 
         return weights

--- a/gaia/scoring/scoring.py
+++ b/gaia/scoring/scoring.py
@@ -1,22 +1,35 @@
+import math
+from typing import List
+
+
+def sigmoid(x: float, k: float = 10, x0: float = 0.55) -> float:
+    """
+    Apply a sigmoid transformation to the raw geo score.
+
+    Parameters:
+      x  : Raw geo score (expected in 0-1 range)
+      k  : Controls the steepness of the sigmoid
+      x0 : The inflection point
+
+    Returns:
+      Transformed score in the range (0,1)
+    """
+    return 1 / (1 + math.exp(-k * (x - x0)))
+
+
 class Scoring:
     """
-    Scoring Class - Instantiated by the validator,
-    Handles aggregation of scores from multiple miners, and calculating final weights.
-
+    Scoring Class - Instantiated by the validator.
+    Handles aggregation of scores from multiple miners and calculates final weights.
     """
 
     def __init__(self, db_manager):
         self.db_manager = db_manager
-        pass
 
     def score(self):
         pass
 
     def _fetch_task_scores(self):
-        """
-        Fetches scores from the database for all tasks. Tasks should submit scores as an array of 256 floats. The scoring run will average these scores in
-        buckets for each tasks.
-        """
         pass
 
     def _aggregate_scores(self):
@@ -26,21 +39,38 @@ class Scoring:
         pass
 
     def aggregate_task_scores(self, geomagnetic_scores: dict, soil_scores: dict) -> List[float]:
-        """Combines scores from multiple tasks into final weights"""
+        """
+        Combines scores from multiple tasks into final weights using a 68/32 weighting scheme,
+        with a sigmoid transformation applied to geo scores.
+
+        - Full miners (both scores available):
+            Effective Score = 0.32 * sigmoid(geo_score) + 0.68 * soil_score
+        - Immune miners (missing soil):
+            Effective Score = 0.32 * sigmoid(geo_score)
+        - If both scores are missing, the effective score is 0.
+        """
         weights = [0.0] * 256
-        
+
         for idx in range(256):
             geo_score = geomagnetic_scores.get(idx, float('nan'))
             soil_score = soil_scores.get(idx, float('nan'))
-            
+
+            # Treat 0.0 as missing (if applicable)
+            if geo_score == 0.0:
+                geo_score = float('nan')
+            if soil_score == 0.0:
+                soil_score = float('nan')
+
             if math.isnan(geo_score) and math.isnan(soil_score):
                 weights[idx] = 0.0
             elif math.isnan(geo_score):
+                # Only soil available
                 weights[idx] = 0.60 * soil_score
             elif math.isnan(soil_score):
-                weights[idx] = 0.40 * math.exp(-abs(geo_score) / 10)
+                # Only geo available; apply sigmoid and take 32%
+                weights[idx] = 0.40 * sigmoid(geo_score, k=20, x0=0.93)
             else:
-                geo_normalized = math.exp(-abs(geo_score) / 10)
-                weights[idx] = 0.40 * geo_normalized + 0.60 * soil_score
-                
+                # Both scores available
+                weights[idx] = 0.40 * sigmoid(geo_score, k=20, x0=0.93) + 0.60 * soil_score
+
         return weights

--- a/gaia/scoring/scoring.py
+++ b/gaia/scoring/scoring.py
@@ -2,7 +2,7 @@ import math
 from typing import List
 
 
-def sigmoid(x: float, k: float = 10, x0: float = 0.55) -> float:
+def sigmoid(x: float, k: float = 20, x0: float = 0.93) -> float:
     """
     Apply a sigmoid transformation to the raw geo score.
 
@@ -40,13 +40,13 @@ class Scoring:
 
     def aggregate_task_scores(self, geomagnetic_scores: dict, soil_scores: dict) -> List[float]:
         """
-        Combines scores from multiple tasks into final weights using a 68/32 weighting scheme,
+        Combines scores from multiple tasks into final weights using a 60/40 weighting scheme,
         with a sigmoid transformation applied to geo scores.
 
         - Full miners (both scores available):
-            Effective Score = 0.32 * sigmoid(geo_score) + 0.68 * soil_score
+            Effective Score = 0.40 * sigmoid(geo_score) + 0.60 * soil_score
         - Immune miners (missing soil):
-            Effective Score = 0.32 * sigmoid(geo_score)
+            Effective Score = 0.40 * sigmoid(geo_score)
         - If both scores are missing, the effective score is 0.
         """
         weights = [0.0] * 256
@@ -67,7 +67,7 @@ class Scoring:
                 # Only soil available
                 weights[idx] = 0.60 * soil_score
             elif math.isnan(soil_score):
-                # Only geo available; apply sigmoid and take 32%
+                # Only geo available; apply sigmoid and take 40%
                 weights[idx] = 0.40 * sigmoid(geo_score, k=20, x0=0.93)
             else:
                 # Both scores available

--- a/gaia/validator/validator.py
+++ b/gaia/validator/validator.py
@@ -1321,11 +1321,11 @@ class GaiaValidator:
                 if np.isnan(geomagnetic_score) and np.isnan(soil_score):
                     weights[idx] = 0.0
                 elif np.isnan(geomagnetic_score):
-                    weights[idx] = 0.75 * soil_score
+                    weights[idx] = 0.60 * soil_score
                 elif np.isnan(soil_score):
-                    weights[idx] = 0.25 * geomagnetic_score
+                    weights[idx] = 0.40 * geomagnetic_score
                 else:
-                    weights[idx] = (0.25 * geomagnetic_score) + (0.75 * soil_score)
+                    weights[idx] = (0.40 * geomagnetic_score) + (0.60 * soil_score)
 
                 logger.info(f"UID {idx}: geo={geomagnetic_score} ({geo_counts[idx]} scores), soil={soil_score} ({soil_counts[idx]} scores), weight={weights[idx]}")
 

--- a/gaia/validator/validator.py
+++ b/gaia/validator/validator.py
@@ -1308,7 +1308,7 @@ class GaiaValidator:
             logger.info("Recent scores fetched and decay-weighted. Calculating aggregate scores...")
 
             # Use a sigmoid transformation for geo scores
-            def sigmoid(x, k=10, x0=0.55):
+            def sigmoid(x, k=20, x0=0.93):
                 return 1 / (1 + math.exp(-k * (x - x0)))
 
             weights = np.zeros(256)

--- a/gaia/validator/validator.py
+++ b/gaia/validator/validator.py
@@ -1321,11 +1321,11 @@ class GaiaValidator:
                 if np.isnan(geomagnetic_score) and np.isnan(soil_score):
                     weights[idx] = 0.0
                 elif np.isnan(geomagnetic_score):
-                    weights[idx] = 0.5 * soil_score
+                    weights[idx] = 0.75 * soil_score
                 elif np.isnan(soil_score):
-                    weights[idx] = 0.5 * geomagnetic_score
+                    weights[idx] = 0.25 * geomagnetic_score
                 else:
-                    weights[idx] = (0.5 * geomagnetic_score) + (0.5 * soil_score)
+                    weights[idx] = (0.25 * geomagnetic_score) + (0.75 * soil_score)
 
                 logger.info(f"UID {idx}: geo={geomagnetic_score} ({geo_counts[idx]} scores), soil={soil_score} ({soil_counts[idx]} scores), weight={weights[idx]}")
 

--- a/gaia/validator/validator.py
+++ b/gaia/validator/validator.py
@@ -1307,6 +1307,10 @@ class GaiaValidator:
 
             logger.info("Recent scores fetched and decay-weighted. Calculating aggregate scores...")
 
+            # Use a sigmoid transformation for geo scores
+            def sigmoid(x, k=10, x0=0.55):
+                return 1 / (1 + math.exp(-k * (x - x0)))
+
             weights = np.zeros(256)
             for idx in range(256):
                 geomagnetic_score = geomagnetic_scores[idx]
@@ -1323,9 +1327,9 @@ class GaiaValidator:
                 elif np.isnan(geomagnetic_score):
                     weights[idx] = 0.60 * soil_score
                 elif np.isnan(soil_score):
-                    weights[idx] = 0.40 * geomagnetic_score
+                    weights[idx] = 0.40 * sigmoid(geomagnetic_score, k=20, x0=0.93)
                 else:
-                    weights[idx] = (0.40 * geomagnetic_score) + (0.60 * soil_score)
+                    weights[idx] = 0.40 * sigmoid(geomagnetic_score, k=20, x0=0.93) + 0.60 * soil_score
 
                 logger.info(f"UID {idx}: geo={geomagnetic_score} ({geo_counts[idx]} scores), soil={soil_score} ({soil_counts[idx]} scores), weight={weights[idx]}")
 


### PR DESCRIPTION
Incentive Ratio Update:
 - 75% weight is now given to soil scores
 - 25% weight is given to geomagnetic scores

• How It Works:
 - If a miner submits both scores, the combined weight is calculated as 25% geo + 75% soil.
 - If one metric is missing, the miner receives only the respective part (0.75× for soil-only or 0.25× for geo-only).
 - This ensures that miners who provide both validated scores—especially the harder-to-produce soil data—gain a significant advantage.

