### PR TITLE
Prevent invalid sentinel_bounds from crashing frontend

### DIFF
--- a/gaia/APIcalls/miner_score_sender.py
+++ b/gaia/APIcalls/miner_score_sender.py
@@ -123,7 +123,11 @@ class MinerScoreSender:
             "predictionId": row["id"],
             "predictionDate": row["target_time"].isoformat(),
             "soilPredictionRegionId": row["region_id"],
-            "sentinelRegionBounds": json.dumps(row["sentinel_bounds"]) if row["sentinel_bounds"] else "[]",
+            "sentinelRegionBounds": row["sentinel_bounds"]
+                if isinstance(row["sentinel_bounds"], list)
+                and len(row["sentinel_bounds"]) == 4
+                and all(isinstance(x, (int, float)) and math.isfinite(x) for x in row["sentinel_bounds"])
+                else [],
             "sentinelRegionCrs": row["sentinel_crs"] if row["sentinel_crs"] else 4326,
             "soilPredictionTargetDate": row["target_time"].isoformat(),
             "soilSurfaceRmse": row["surface_rmse"],

--- a/gaia/tasks/defined_tasks/soilmoisture/soil_scoring_mechanism.py
+++ b/gaia/tasks/defined_tasks/soilmoisture/soil_scoring_mechanism.py
@@ -650,7 +650,7 @@ class SoilScoringMechanism(ScoringMechanism):
             logger.error(traceback.format_exc())
             return False
 
-    def prepare_soil_history_records(self, miner_id: str, miner_hotkey: str, metrics: Dict, target_time: datetime) -> Dict[str, Any]:
+    def prepare_soil_history_records(self, miner_id: str, miner_hotkey: str, metrics: Dict, target_time: datetime, region_id: int = None) -> Dict[str, Any]:
         """
         Prepare data for insertion into the soil_moisture_history table.
 
@@ -686,6 +686,9 @@ class SoilScoringMechanism(ScoringMechanism):
                 "rootzone_structure_score": rootzone_ssim,
                 "scored_at": target_time,
             }
+            if region_id is not None:
+                record["region_id"] = region_id  # 👈 This enables `sentinel_bounds` to show up later
+
             return record
 
         except Exception as e:


### PR DESCRIPTION
Sanitized sentinel_bounds in miner_score_sender.py:

Updated `_process_soil_row_sync()` to check that:

- sentinel_bounds is a list of exactly 4 values.

- All values are finite numbers (int or float, no NaN, inf, or None).

- Fallbacks to an empty list ([]) if invalid, preventing malformed data from being sent to the frontend.



Addresses TypeError: coordinates must be finite numbers in soilUtils.ts → reprojectBounds() by ensuring only valid bounds are passed through the API payload.

