### PR TITLE
Fix some issues in install

### DIFF
--- a/gaia/tasks/defined_tasks/weather/utils/gfs_api.py
+++ b/gaia/tasks/defined_tasks/weather/utils/gfs_api.py
@@ -657,6 +657,7 @@ async def fetch_gfs_analysis_data(
             combined_ds = xr.concat(analysis_slices, dim='time')
             
             # MEMORY LEAK FIX: Clean up individual slices after concat to free memory
+            len_analysis_slices = len(analysis_slices)
             for slice_ds in analysis_slices:
                 try:
                     slice_ds.close()
@@ -668,7 +669,7 @@ async def fetch_gfs_analysis_data(
             # Force garbage collection after concat
             import gc
             collected = gc.collect()
-            logger.debug(f"Post-concat cleanup: freed {len(analysis_slices)} slices, GC collected {collected} objects")
+            logger.debug(f"Post-concat cleanup: freed {len_analysis_slices} slices, GC collected {collected} objects")
             
         except Exception as e_concat:
              logger.error(f"Failed to combine analysis slices: {e_concat}")
@@ -798,7 +799,7 @@ async def fetch_gfs_analysis_data(
         
         # Update final progress info
         progress_info.update({
-            "processed_files": len(analysis_slices),
+            "processed_files": len_analysis_slices,
             "completed": True,
             "step_progress": 0.8  # Processing complete, ready for caching
         })

--- a/gaia/validator/database/comprehensive_db_setup.py
+++ b/gaia/validator/database/comprehensive_db_setup.py
@@ -256,7 +256,7 @@ class ComprehensiveDatabaseSetup:
             ]
             success, stdout, stderr = await self._run_command(check_alembic_cmd, timeout=10)
             # PostgreSQL returns 't' for true, 'f' for false
-            if not success or 't' not in stdout.strip():
+            if not success or 't' not in stdout.strip().replace('exists', '').strip():
                 logger.info("❌ Alembic not configured")
                 return False
             

--- a/requirements.txt
+++ b/requirements.txt
@@ -740,6 +740,7 @@ zarr==2.18.3
     #   kerchunk
 zipp==3.21.0
     # via importlib-metadata
+cfgrib
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
This PR fixes issues:
1 - add missed requirement  ( cfgrib )
Missed requirement causes error in soil task when validator tries to get smap data :
```
Error loading t2m: unrecognized engine 'cfgrib' must be one of your download engines: ['netcdf4', 'h5netcdf', 'scipy', 'gini', 'kerchunk', 'store', 'zarr']. To install additional dependencies, see:                                                                                                                                                                   
0|gaia-validator  | https://docs.xarray.dev/en/stable/user-guide/io.html 
```
2 - fix _check_if_already_configured() method.
Now it always returns "Database system is already properly configured" if DB exists, even if there are no tables.
This happens due to format of stdout.strip():
```
exists 
--------
 f
(1 row)
```
"t" always in responce due to word "exists"

3 - Fix weather task. Now it does not work due to errors:
```
0|gaia-validator  | 2025-06-29 18:20:42.161 | ERROR | gfs_api:_sync_fetch_and_process_analysis:674 - Failed to combine analysis slices: local variable 'analysis_slices' referenced before ass
ignment
0|gaia-validator  | 2025-06-29 18:20:42.166 | ERROR | gfs_api:fetch_gfs_analysis_data:847 - Async fetch GFS analysis data failed: local variable 'analysis_slices' referenced before assignmen
t
0|gaia-validator  | 2025-06-29 18:20:42.167 | ERROR | hashing:compute_input_data_hash:818 - Failed to fetch GFS data for hash computation.
0|gaia-validator  | 2025-06-29 18:20:42.167 | ERROR | weather_task:validator_execute:1601 - [Run 1] Validator failed to compute its own reference input hash. Cannot verify miners.
0|gaia-validator  | 2025-06-29 18:20:42.167 | INFO | weather_logic:_update_run_status:40 - [Run 1] Updating run status to 'error'.
```

