### PR TITLE
clean up functions and bounds added

### DIFF
--- a/gaia/validator/validator.py
+++ b/gaia/validator/validator.py
@@ -4160,6 +4160,27 @@ class GaiaValidator:
                                                 )
                                             except Exception:
                                                 pass
+                                            # Clean up old validator jobs (24 hours retention)
+                                            try:
+                                                cleaned_count = await self.database_manager.cleanup_old_validator_jobs(hours_after_completion=24)
+                                                if cleaned_count > 0:
+                                                    logger.info(f"[cleanup] Deleted {cleaned_count} old validator jobs (24h retention)")
+                                            except Exception as cleanup_err:
+                                                logger.debug(f"Validator jobs cleanup error: {cleanup_err}")
+                                            # Clean up old weather miner responses (20 days retention)
+                                            try:
+                                                cleaned_responses = await self.database_manager.cleanup_old_weather_miner_responses(days_to_keep=20)
+                                                if cleaned_responses > 0:
+                                                    logger.info(f"[cleanup] Deleted {cleaned_responses} old weather miner responses (20d retention)")
+                                            except Exception as cleanup_err:
+                                                logger.debug(f"Weather miner responses cleanup error: {cleanup_err}")
+                                            # Clean up old weather forecast stats (30 days retention)
+                                            try:
+                                                cleaned_stats = await self.database_manager.cleanup_old_weather_forecast_stats(days_to_keep=30)
+                                                if cleaned_stats > 0:
+                                                    logger.info(f"[cleanup] Deleted {cleaned_stats} old weather forecast stats (30d retention)")
+                                            except Exception as cleanup_err:
+                                                logger.debug(f"Weather forecast stats cleanup error: {cleanup_err}")
                                         except Exception as agg_err:
                                             logger.debug(f"Stats aggregation error: {agg_err}")
                                         await asyncio.sleep(interval_sec)


### PR DESCRIPTION
Implemented So Far:
:white_check_mark: validator_jobs cleanup - 24-hour retention (was 7 days)
:white_check_mark: weather_miner_responses cleanup - 20-day retention (was unbounded)
:white_check_mark: weather_forecast_stats cleanup - 30-day retention (was unbounded)
:white_check_mark: baseline_predictions cleanup - 15-day retention (was 30 days)
:white_check_mark: weather_forecast_steps cleanup - 15-day retention (was 30 days)
:white_check_mark: geomagnetic_predictions cleanup - 15-day retention (was 30 days)

Expected Impact:
Monster query should be much faster - Now scans 30 days instead of all time
Memory pressure should reduce - Less data in memory
Database timeouts should decrease - Shorter operations
Storage should shrink - Significant cleanup of old data